### PR TITLE
Update marshmallow/translatable to version 5.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "marshmallow/nova-advanced-image": "^2.0",
         "marshmallow/nova-flexible": "^5.0",
         "marshmallow/nova-fields-help": "^v2.0",
-        "marshmallow/translatable": "^2.0",
+        "marshmallow/translatable": "^5.0",
         "laravel/nova": "^5.0",
         "marshmallow/nova-multiselect-field": "^5.0"
     },


### PR DESCRIPTION
## Summary
- Updated marshmallow/translatable from version ^2.0 to ^5.0 
- Resolves issue #108

## Changes
- Modified composer.json to require marshmallow/translatable ^5.0
- Ran composer update to install the new version

## Compatibility
- No breaking changes detected in the codebase usage
- The Translatable trait usage remains the same
- All existing functionality should continue to work as expected

## Testing
- Verified that the package successfully updated to version 5.0.0
- No code changes required due to backward compatibility