### PR TITLE
fix: emit valid flat JSON-LD schema nodes

### DIFF
--- a/src/Helpers/Schemas/SchemaAggregateRating.php
+++ b/src/Helpers/Schemas/SchemaAggregateRating.php
@@ -43,9 +43,6 @@ class SchemaAggregateRating extends Schema
             $data['name'] = $this->name;
         }
 
-        return [
-            '@type' => 'AggregateRating',
-            '@graph' => $data,
-        ];
+        return $data;
     }
 }

--- a/src/Helpers/Schemas/SchemaAnswer.php
+++ b/src/Helpers/Schemas/SchemaAnswer.php
@@ -11,11 +11,8 @@ class SchemaAnswer extends Schema
     public function toArray()
     {
         return [
-            '@type' => 'Answer',
-            '@graph' => [
                 '@type' => 'Answer',
                 'text' => $this->name,
-            ]
         ];
     }
 }

--- a/src/Helpers/Schemas/SchemaBrand.php
+++ b/src/Helpers/Schemas/SchemaBrand.php
@@ -11,11 +11,8 @@ class SchemaBrand extends Schema
     public function toJson()
     {
         return [
-            '@type' => 'Brand',
-            '@graph' => [
                 '@type' => 'Brand',
                 'name' => $this->name,
-            ]
         ];
     }
 }

--- a/src/Helpers/Schemas/SchemaBreadcrumbList.php
+++ b/src/Helpers/Schemas/SchemaBreadcrumbList.php
@@ -31,11 +31,8 @@ class SchemaBreadcrumbList extends Schema
     public function toArray()
     {
         return [
-            '@context' => 'https://schema.org',
-            '@graph' => [
                 '@type' => 'BreadcrumbList',
                 'itemListElement' => $this->itemListElement,
-            ]
         ];
     }
 }

--- a/src/Helpers/Schemas/SchemaFaqPage.php
+++ b/src/Helpers/Schemas/SchemaFaqPage.php
@@ -32,11 +32,8 @@ class SchemaFaqPage extends Schema
     public function toArray()
     {
         return [
-            '@context' => 'https://schema.org',
-            '@graph' => [
                 '@type' => 'FAQPage',
                 'mainEntity' => $this->questions,
-            ],
         ];
     }
 }

--- a/src/Helpers/Schemas/SchemaGeoCoordinates.php
+++ b/src/Helpers/Schemas/SchemaGeoCoordinates.php
@@ -14,12 +14,9 @@ class SchemaGeoCoordinates extends Schema
     public function toArray()
     {
         return [
-            '@type' => 'GeoCoordinates',
-            '@graph' => [
                 '@type' => 'GeoCoordinates',
                 'latitude' => $this->latitude,
                 'longitude' => $this->longitude,
-            ]
         ];
     }
 }

--- a/src/Helpers/Schemas/SchemaHowToStep.php
+++ b/src/Helpers/Schemas/SchemaHowToStep.php
@@ -26,14 +26,11 @@ class SchemaHowToStep extends Schema
     public function toJson()
     {
         return [
-            '@type' => 'HowToStep',
-            '@graph' => [
                 '@type' => 'HowToStep',
                 'name' => $this->name,
                 'text' => $this->text,
                 'url' => $this->url,
                 'image' => $this->image,
-            ]
         ];
     }
 }

--- a/src/Helpers/Schemas/SchemaInteractionCounter.php
+++ b/src/Helpers/Schemas/SchemaInteractionCounter.php
@@ -19,14 +19,11 @@ class SchemaInteractionCounter extends Schema
     public function toJson()
     {
         return [
-            '@type' => 'InteractionCounter',
-            '@graph' => [
                 '@type' => 'InteractionCounter',
                 'interactionType' => [
                     '@type' => 'http://schema.org/' . $this->type,
                 ],
                 'userInteractionCount' => $this->count,
-            ]
         ];
     }
 }

--- a/src/Helpers/Schemas/SchemaLocalBusiness.php
+++ b/src/Helpers/Schemas/SchemaLocalBusiness.php
@@ -34,8 +34,6 @@ class SchemaLocalBusiness extends Schema
     public function toArray()
     {
         return [
-            '@context' => 'https://schema.org/',
-            '@graph' => [
                 '@type' => $this->type,
                 '@id' => $this->id,
                 'name' => $this->name,
@@ -47,7 +45,6 @@ class SchemaLocalBusiness extends Schema
                 'telephone' => $this->telephone,
                 'aggregateRating' => $this->aggregateRating,
                 'openingHoursSpecification' => $this->openingHoursSpecification,
-            ],
         ];
     }
 }

--- a/src/Helpers/Schemas/SchemaNutritionInformation.php
+++ b/src/Helpers/Schemas/SchemaNutritionInformation.php
@@ -100,8 +100,6 @@ class SchemaNutritionInformation extends Schema
     public function toArray()
     {
         return [
-            '@type' => 'NutritionInformation',
-            '@graph' => [
                 '@type' => 'NutritionInformation',
                 'calories' => $this->calories,
                 'carbohydrateContent' => $this->carbohydrateContent,
@@ -115,7 +113,6 @@ class SchemaNutritionInformation extends Schema
                 'sugarContent' => $this->sugarContent,
                 'transFatContent' => $this->transFatContent,
                 'unsaturatedFatContent' => $this->unsaturatedFatContent,
-            ]
         ];
     }
 }

--- a/src/Helpers/Schemas/SchemaOffer.php
+++ b/src/Helpers/Schemas/SchemaOffer.php
@@ -76,8 +76,6 @@ class SchemaOffer extends Schema
     public function toArray()
     {
         return [
-            '@type' => 'Offer',
-            '@graph' => [
                 '@type' => 'Offer',
                 'url' => $this->url,
                 'availability' => 'http://schema.org/' . $this->availability,
@@ -85,7 +83,6 @@ class SchemaOffer extends Schema
                 'price' => $this->price,
                 'priceValidUntil' => $this->priceValidUntil,
                 'priceCurrency' => $this->priceCurrency,
-            ]
         ];
     }
 }

--- a/src/Helpers/Schemas/SchemaOpeningHoursSpecification.php
+++ b/src/Helpers/Schemas/SchemaOpeningHoursSpecification.php
@@ -17,13 +17,10 @@ class SchemaOpeningHoursSpecification extends Schema
     public function toArray()
     {
         return [
-            '@type' => 'OpeningHoursSpecification',
-            '@graph' => [
                 '@type' => 'OpeningHoursSpecification',
                 'dayOfWeek' => $this->dayOfWeek,
                 'opens' => $this->opens,
                 'closes' => $this->closes,
-            ]
         ];
     }
 }

--- a/src/Helpers/Schemas/SchemaOrganization.php
+++ b/src/Helpers/Schemas/SchemaOrganization.php
@@ -36,9 +36,6 @@ class SchemaOrganization extends Schema
             $data['vatID'] = config('seo.defaults.vat_id');
         }
 
-        return [
-            '@context' => 'https://schema.org',
-            '@graph' => $data,
-        ];
+        return $data;
     }
 }

--- a/src/Helpers/Schemas/SchemaPerson.php
+++ b/src/Helpers/Schemas/SchemaPerson.php
@@ -11,11 +11,8 @@ class SchemaPerson extends Schema
     public function toArray()
     {
         return [
-            '@type' => 'Person',
-            '@graph' => [
                 '@type' => 'Person',
                 'name' => $this->name,
-            ]
         ];
     }
 }

--- a/src/Helpers/Schemas/SchemaPostalAddress.php
+++ b/src/Helpers/Schemas/SchemaPostalAddress.php
@@ -17,15 +17,12 @@ class SchemaPostalAddress extends Schema
     public function toArray()
     {
         return [
-            '@type' => 'PostalAddress',
-            '@graph' => [
                 '@type' => 'PostalAddress',
                 'streetAddress' => $this->address,
                 'addressLocality' => $this->locality,
                 'addressRegion' => $this->region,
                 'postalCode' => $this->postalCode,
                 'addressCountry' => $this->country,
-            ]
         ];
     }
 }

--- a/src/Helpers/Schemas/SchemaPostalAddress.php
+++ b/src/Helpers/Schemas/SchemaPostalAddress.php
@@ -14,6 +14,17 @@ class SchemaPostalAddress extends Schema
     public $postalCode;
     public $country;
 
+    /**
+     * The magic __call would set an unused $street property, so
+     * streetAddress silently never rendered.
+     */
+    public function street(?string $street)
+    {
+        $this->address = $street;
+
+        return $this;
+    }
+
     public function toArray()
     {
         return [

--- a/src/Helpers/Schemas/SchemaProduct.php
+++ b/src/Helpers/Schemas/SchemaProduct.php
@@ -50,8 +50,6 @@ class SchemaProduct extends Schema
     public function toArray()
     {
         return [
-            '@context' => 'https://schema.org/',
-            '@graph' => [
                 '@type' => 'Product',
                 'name' => $this->name,
                 'image' => $this->images,
@@ -64,7 +62,6 @@ class SchemaProduct extends Schema
                 'isbn' => $this->isbn,
                 'aggregateRating' => $this->aggregateRating,
                 'review' => $this->reviews,
-            ],
         ];
     }
 }

--- a/src/Helpers/Schemas/SchemaQuestion.php
+++ b/src/Helpers/Schemas/SchemaQuestion.php
@@ -20,12 +20,9 @@ class SchemaQuestion extends Schema
     public function toArray()
     {
         return [
-            '@type' => 'Question',
-            '@graph' => [
                 '@type' => 'Question',
                 'name' => $this->name,
                 'acceptedAnswer' => $this->answer->toArray(),
-            ]
         ];
     }
 }

--- a/src/Helpers/Schemas/SchemaRating.php
+++ b/src/Helpers/Schemas/SchemaRating.php
@@ -19,13 +19,10 @@ class SchemaRating extends Schema
     public function toJson()
     {
         return [
-            '@type' => 'Rating',
-            '@graph' => [
                 '@type' => 'Rating',
                 'bestRating' => $this->bestRating,
                 'ratingValue' => $this->ratingValue,
                 'worstRating' => $this->worstRating,
-            ]
         ];
     }
 }

--- a/src/Helpers/Schemas/SchemaRecipe.php
+++ b/src/Helpers/Schemas/SchemaRecipe.php
@@ -137,8 +137,6 @@ class SchemaRecipe extends Schema
     public function toArray()
     {
         return [
-            '@context' => 'https://schema.org/',
-            '@graph' => [
                 '@type' => 'Recipe',
                 'name' => $this->name,
                 'image' => $this->images,
@@ -157,7 +155,6 @@ class SchemaRecipe extends Schema
                 'recipeIngredient' => $this->recipeIngredient,
                 'recipeInstructions' => $this->recipeInstructions,
                 'video' => $this->getJsonSchema('video'),
-            ],
         ];
     }
 }

--- a/src/Helpers/Schemas/SchemaReview.php
+++ b/src/Helpers/Schemas/SchemaReview.php
@@ -27,17 +27,23 @@ class SchemaReview extends Schema
 
     public function toJson()
     {
-        return [
+        $data = [
             '@type' => 'Review',
-            '@graph' => [
-                '@type' => 'Review',
-                'author' => $this->author,
-                'datePublished' => $this->datePublished,
-                'name' => $this->name,
-                'reviewRating' => $this->rating(
-                    SchemaRating::make($this->ratingValue)
-                ),
-            ]
+            'datePublished' => $this->datePublished,
+            'name' => $this->name,
         ];
+
+        if ($this->author) {
+            $data['author'] = [
+                '@type' => 'Person',
+                'name' => $this->author,
+            ];
+        }
+
+        if ($this->ratingValue !== null) {
+            $data['reviewRating'] = SchemaRating::make((float) $this->ratingValue)->toJson();
+        }
+
+        return $data;
     }
 }

--- a/src/Helpers/Schemas/SchemaVideoObject.php
+++ b/src/Helpers/Schemas/SchemaVideoObject.php
@@ -76,8 +76,6 @@ class SchemaVideoObject extends Schema
     public function toJson()
     {
         return [
-            '@type' => 'VideoObject',
-            '@graph' => [
                 '@type' => 'VideoObject',
                 'name' => $this->name,
                 'description' => $this->description,
@@ -88,7 +86,6 @@ class SchemaVideoObject extends Schema
                 'duration' => $this->duration,
                 'interactionStatistic' => $this->getJsonSchema('interactionStatistic'),
                 'expires' => $this->expires,
-            ]
         ];
     }
 }


### PR DESCRIPTION
Every schema class wrapped its payload in an extra `'@type' + '@graph'` level, and the top-level classes added their own `@context`. The rendered output therefore nested `@graph` objects inside the `@graph` array on every page, which schema validators (and Google's rich result parsing) reject - in practice sites using these schemas get no rich results from them.

- All 21 schema classes now return a flat schema.org node; the single `@context`/`@graph` wrapper is added once in `Seo::getSchema()`.
- `SchemaReview` serialised a fluent self-reference into `reviewRating` (always `{}`) and a bare string as `author`; it now outputs a proper `Rating` node and a `Person` author.

Verified against oogvoororen.nl locally: the PDP now renders one valid JSON-LD block (`OnlineStore` + `Product` incl. Brand/Offer/AggregateRating/82 Reviews + `BreadcrumbList`) that parses cleanly.

Found while working on the Horama SEO audit (MM-25061/MM-25100).